### PR TITLE
Fix path to provide phoneme durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ python3 synthesize.py --text "YOUR_DESIRED_TEXT" --restore_step 900000 --mode si
 ```
 
 Phoneme durations can be controlled by specifying custom durations. Lets say you want to modify the durations of speaker `LJ001` and basename `LJ001-0001`, you would have to modify the corresponding preprocessed file to your customized durations, in this case the following file
-`durations/LJSpeech/LJSpeech-duration-LJ001-0001.npy`
+`preprocessed_data/LJSpeech/duration/LJSpeech-duration-LJ001-0001.npy`
 
 Once modified, simply run the synthesize command in **batch** mode. 
 


### PR DESCRIPTION
This is the path read for durations in batch mode
https://github.com/Proyag/FastSpeech2/blob/236064b5ab2e0489b9122fa2ccfdb33e529e1cb4/dataset.py#L176-L180